### PR TITLE
Noteコンポーネントの編集モード時のタイトル、content、ラベルの編集可否テストを追加

### DIFF
--- a/packages/frontend/src/components/Note.tsx
+++ b/packages/frontend/src/components/Note.tsx
@@ -358,7 +358,7 @@ export default function Note({
                             <>
                                 <Button onClick={handleSave} variant="contained" sx={{ mr: 1 }}>保存</Button>
                                 <Button onClick={() => setIsEditing(false)} variant="contained">キャンセル</Button>
-                                <FormControl size="small" sx={{ minWidth: 120, ml: 2 }}>
+                                <FormControl size="small" sx={{ minWidth: 120, ml: 2 }} data-testid="label-select">
                                     <InputLabel id="select-label">ラベル</InputLabel>
                                     <Select
                                         labelId="select-label"

--- a/packages/frontend/test/components/Note.test.tsx
+++ b/packages/frontend/test/components/Note.test.tsx
@@ -1,11 +1,7 @@
 import React, { act } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Note from "../../src/components/Note";
-import { LabelProvider } from "@/context/LabelProvider";
-import { NoteProvider } from "@/context/NoteProvider";
-
-
 // ラベルコンテキストのモック
 const mockLabels = [
     { id: "label1", labelname: "仕事" },
@@ -21,6 +17,10 @@ jest.mock("@/context/LabelProvider", () => {
         LabelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     };
 });
+
+import { LabelProvider } from "@/context/LabelProvider";
+import { NoteProvider } from "@/context/NoteProvider";
+
 
 describe("Note", () => {
     const mockOnSave = jest.fn();
@@ -66,5 +66,88 @@ describe("Note", () => {
         expect(screen.getByText("削除")).toBeVisible();
         expect(screen.getByTestId("unlock")).toBeVisible();
     })
+
+    it("編集モード時、タイトルを編集できる", async () => {
+        render(
+            <NoteProvider>
+                <LabelProvider>
+                    <Note id={"testid111"} title={"テストノートタイトル"} content={"テストノートcontent"} label_id={""} createdate="2025-07-05 05:33:05.864" updatedate="2025-07-05 05:33:05.864" is_locked={false} onSave={mockOnSave} onDelete={mockOnDelete} />
+                </LabelProvider>
+            </NoteProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("テストノートタイトル"));
+        })
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("編集"));
+        })
+
+        const titleInput = screen.getByDisplayValue("テストノートタイトル") as HTMLInputElement;
+
+        await act(async () => {
+            fireEvent.change(titleInput, { target: { value: "新しいタイトル" } });
+        });
+
+        expect(titleInput.value).toBe("新しいタイトル");
+
+    });
+
+    it("編集モード時、contentを編集できる", async () => {
+        render(
+            <NoteProvider>
+                <LabelProvider>
+                    <Note id={"testid111"} title={"テストノートタイトル"} content={"テストノートcontent"} label_id={""} createdate="2025-07-05 05:33:05.864" updatedate="2025-07-05 05:33:05.864" is_locked={false} onSave={mockOnSave} onDelete={mockOnDelete} />
+                </LabelProvider>
+            </NoteProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("テストノートタイトル"));
+        })
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("編集"));
+        })
+
+        const contentInput = screen.getByDisplayValue("テストノートcontent") as HTMLInputElement;
+
+        await act(async () => {
+            fireEvent.change(contentInput, { target: { value: "新しいcontent" } });
+        });
+
+        expect(contentInput.value).toBe("新しいcontent");
+
+    });
+
+    it("編集モード時、ラベルを編集できる", async () => {
+        render(
+            <NoteProvider>
+                <LabelProvider>
+                    <Note id={"testid111"} title={"テストノートタイトル"} content={"テストノートcontent"} label_id={"label1"} createdate="2025-07-05 05:33:05.864" updatedate="2025-07-05 05:33:05.864" is_locked={false} onSave={mockOnSave} onDelete={mockOnDelete} />
+                </LabelProvider>
+            </NoteProvider>
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("テストノートタイトル"));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("編集"));
+        });
+
+
+        fireEvent.mouseDown(screen.getByTestId("label-select").querySelector('[role="combobox"]')!);
+
+        // リストが出現するのを待つ
+        const option = await screen.findByText("プライベート");
+
+        fireEvent.click(option);
+
+        // 選択できたか確認
+        expect(screen.getByTestId("label-select")).toHaveTextContent("プライベート");
+    });
 
 });


### PR DESCRIPTION
#3 