### PR TITLE
テーブルノートの入力欄の幅を調整して、カラムのデフォルト値を消してプレースホルダーに変更

### DIFF
--- a/packages/frontend/src/app/(authenticated)/components/InputForm.tsx
+++ b/packages/frontend/src/app/(authenticated)/components/InputForm.tsx
@@ -63,7 +63,7 @@ export default function InputForm({ onInsert, onInsertTableNote }: InputFormProp
 
     // テーブルノート用
     const [editColumns, setEditColumns] = useState<Column[]>([
-        { id: 1, name: "カラム1", order: 1 }
+        { id: 1, name: "", order: 1 }
     ]);
     const [editRowCells, setEditRowCells] = useState<RowCell[][]>([[{
         id: 1,
@@ -73,6 +73,11 @@ export default function InputForm({ onInsert, onInsertTableNote }: InputFormProp
     }]]);
 
     const blurTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+    // 行削除
+    const handleDeleteRow = (rowIdx: number) => {
+        if (editRowCells.length <= 1) return;
+        setEditRowCells(editRowCells.filter((_, idx) => idx !== rowIdx));
+    };
 
     const handleExpand = () => { setExpand(true) };
     const handleCollapse = () => {
@@ -193,7 +198,7 @@ export default function InputForm({ onInsert, onInsertTableNote }: InputFormProp
     const handleAddColumn = () => {
         const addColumnId = Date.now();
         if (editColumns.length >= 5) return;
-        setEditColumns([...editColumns, { id: addColumnId, name: `カラム${editColumns.length + 1}` }]);
+        setEditColumns([...editColumns, { id: addColumnId, name: "" }]);
         setEditRowCells(editRowCells.map(editRowCell => [...editRowCell, { id: Date.now(), rowIndex: editRowCell.length, value: "", columnId: addColumnId }]));
     };
 
@@ -334,16 +339,22 @@ export default function InputForm({ onInsert, onInsertTableNote }: InputFormProp
                                                 newColumns[idx] = { ...newColumns[idx], name: e.target.value };
                                                 setEditColumns(newColumns);
                                             }}
-                                            sx={{ width: 200 }}
+                                            placeholder={`カラム${idx + 1}`}
+                                            sx={{
+                                                minWidth: 80,
+                                                width: { xs: '35vw', sm: 200 },
+                                                maxWidth: '100%'
+                                            }}
+                                            data-testid="column-input"
                                         />
                                         <IconButton size="small" onClick={() => handleDeleteColumn(idx)} disabled={editColumns.length <= 1}>
-                                            <DeleteIcon fontSize="small" />
+                                            <DeleteIcon fontSize="small" data-testid="deletecolumnicon" />
                                         </IconButton>
                                     </TableCell>
                                 ))}
                                 <TableCell>
                                     <IconButton onClick={handleAddColumn} disabled={editColumns.length >= 5}>
-                                        <AddIcon />
+                                        <AddIcon data-testid="addColumnIcon" />
                                     </IconButton>
                                 </TableCell>
                             </TableRow>
@@ -357,10 +368,24 @@ export default function InputForm({ onInsert, onInsertTableNote }: InputFormProp
                                                 value={cell.value}
                                                 onChange={e => handleCellChange(rowIdx, colIdx, e.target.value)}
                                                 variant="outlined"
-                                                sx={{ width: 200 }}
+                                                sx={{
+                                                    minWidth: 80,
+                                                    width: { xs: '35vw', sm: 200 },
+                                                    maxWidth: '100%'
+                                                }}
                                             />
                                         </TableCell>
                                     ))}
+                                    <TableCell>
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => handleDeleteRow(rowIdx)}
+                                            disabled={editRowCells.length <= 1}
+                                            data-testid="deleterowicon"
+                                        >
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>

--- a/packages/frontend/src/app/(authenticated)/components/TableNote.tsx
+++ b/packages/frontend/src/app/(authenticated)/components/TableNote.tsx
@@ -92,7 +92,7 @@ export default function TableNote({ id, title, label_id, is_locked, createdate, 
     const handleAddColumn = () => {
         const addColumnId = Date.now();
         if (editColumns.length >= 5) return;
-        setEditColumns([...editColumns, { id: addColumnId, name: `カラム${editColumns.length + 1}` }]);
+        setEditColumns([...editColumns, { id: addColumnId, name: "" }]);
         setEditRowCells(editRowCells.map(rowCell => [...rowCell, { id: Date.now(), rowIndex: rowCell.length, value: "", columnId: addColumnId }]));
     };
 
@@ -421,7 +421,13 @@ export default function TableNote({ id, title, label_id, is_locked, createdate, 
                                                         newColumns[idx] = { ...newColumns[idx], name: e.target.value };
                                                         setEditColumns(newColumns);
                                                     }}
-                                                    sx={{ width: 200 }}
+                                                    placeholder={`カラム${idx + 1}`}
+                                                    sx={{
+                                                        minWidth: 80,
+                                                        width: { xs: '35vw', sm: 200 },
+                                                        maxWidth: '100%'
+                                                    }}
+                                                    data-testid="column-input"
                                                 />
                                                 <IconButton size="small" onClick={() => handleDeleteColumn(idx)} disabled={editColumns.length <= 1}>
                                                     <DeleteIcon fontSize="small" data-testid="deletecolumnicon" />
@@ -444,7 +450,11 @@ export default function TableNote({ id, title, label_id, is_locked, createdate, 
                                                         value={cell.value}
                                                         onChange={e => handleCellChange(rowIdx, colIdx, e.target.value)}
                                                         variant="outlined"
-                                                        sx={{ width: 200 }}
+                                                        sx={{
+                                                            minWidth: 80,
+                                                            width: { xs: '35vw', sm: 200 },
+                                                            maxWidth: '100%'
+                                                        }}
                                                     />
                                                 </TableCell>
                                             ))}

--- a/packages/frontend/test/app/(authenticated)/components/InputForm.test.tsx
+++ b/packages/frontend/test/app/(authenticated)/components/InputForm.test.tsx
@@ -226,7 +226,7 @@ describe("InputForm", () => {
             fireEvent.click(tableNoteIcon);
         });
 
-        const column1 = await screen.getByDisplayValue("カラム1");
+        const column1 = await screen.getByTestId("column-input");
 
         await waitFor(() => {
             expect(column1).toBeVisible();

--- a/packages/frontend/test/app/(authenticated)/components/TableNote.test.tsx
+++ b/packages/frontend/test/app/(authenticated)/components/TableNote.test.tsx
@@ -160,7 +160,7 @@ describe("TableNote", () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByDisplayValue("カラム2")).toBeInTheDocument();
+            expect(screen.getAllByTestId("column-input").length).toBeGreaterThan(mockColumns.length);
         });
     });
 


### PR DESCRIPTION
Close #198 
#199 