### PR TITLE
パスワード入力欄の警告を解消、ノートとテーブルノートの非拡大時のラベルの上マージンを設定、トップページに出ていたアイコンサイズに関する警告を解消

### DIFF
--- a/packages/frontend/src/app/(authenticated)/components/Note.tsx
+++ b/packages/frontend/src/app/(authenticated)/components/Note.tsx
@@ -346,7 +346,7 @@ export default function Note({
                     {t("label_updatedate")}: {formatDate(updatedate)}
                 </Typography>
                 {label_id && label_id.trim() !== "" && getLabelName(label_id) && (
-                    <Typography variant="caption" color="textSecondary" sx={{ mb: 1, border: "1px solid #ccc", p: 0.5, borderRadius: 1 }}>
+                    <Typography variant="caption" color="textSecondary" sx={{ mb: 1, mt: 1, border: "1px solid #ccc", p: 0.5, borderRadius: 1, display: "inline-block" }}>
                         {getLabelName(label_id)}
                     </Typography>
                 )}

--- a/packages/frontend/src/app/(authenticated)/components/TableNote.tsx
+++ b/packages/frontend/src/app/(authenticated)/components/TableNote.tsx
@@ -441,7 +441,7 @@ export default function TableNote({ id, title, label_id, is_locked, createdate, 
                     {t("label_updatedate")}: {formatDate(updatedate)}
                 </Typography>
                 {label_id && label_id.trim() !== "" && getLabelName(label_id) && (
-                    <Typography variant="caption" color="textSecondary" sx={{ mb: 1, border: "1px solid #ccc", p: 0.5, borderRadius: 1 }}>
+                    <Typography variant="caption" color="textSecondary" sx={{ mb: 1, mt: 1, border: "1px solid #ccc", p: 0.5, borderRadius: 1 }}>
                         {getLabelName(label_id)}
                     </Typography>
                 )}

--- a/packages/frontend/src/app/(authenticated)/layout.tsx
+++ b/packages/frontend/src/app/(authenticated)/layout.tsx
@@ -265,6 +265,7 @@ function InnerLayout({ children }: { children: React.ReactNode }) {
 									src="/Hoard_icon.png"
 									alt="Hoard Icon"
 									fill
+									priority
 									sizes="55px"
 									style={{ objectFit: "contain", objectPosition: "left" }}
 								/>

--- a/packages/frontend/src/app/(authenticated)/settings/page.tsx
+++ b/packages/frontend/src/app/(authenticated)/settings/page.tsx
@@ -271,7 +271,7 @@ export default function Home() {
         />
         <br />
         <TextField
-          id="new-password"
+          id="current-password"
           variant="outlined"
           value={prevPasswordString}
           onChange={(e) => setPrevPasswordString(e.target.value)}


### PR DESCRIPTION
Close #236 
Close #228 